### PR TITLE
Fix: Clear desired state after natural cleaning cycle completion

### DIFF
--- a/custom_components/iaqualink_robots/coordinator.py
+++ b/custom_components/iaqualink_robots/coordinator.py
@@ -1785,6 +1785,47 @@ class AqualinkClient:
                     except Exception as e:
                         _LOGGER.debug(f"Error triggering immediate callback: {e}")
 
+    async def clear_desired_state(self):
+        """Clear the desired state to prevent auto-restart after natural cycle completion.
+
+        When the robot finishes cleaning naturally, the cloud may still have
+        desired state = 1 (cleaning). This can cause the cloud to restart the robot.
+        This method sets desired state = 0 to prevent that.
+        """
+        # Only implemented for vr - tested on Polaris VRX IQ+
+        # Other device types (vortrax, cyclobat, cyclonext) may need similar
+        # treatment if they exhibit the same auto-restart bug
+        if self._device_type != "vr":
+            return
+
+        clientToken = f"{self._id}|{self._auth_token}|{self._app_client_id}"
+
+        request = {
+            "action": "setCleanerState",
+            "version": 1,
+            "namespace": self._device_type,
+            "payload": {
+                "state": {
+                    "desired": {
+                        "equipment": {
+                            "robot": {
+                                "state": 0
+                            }
+                        }
+                    }
+                },
+                "clientToken": clientToken
+            },
+            "service": "StateController",
+            "target": self._serial
+        }
+
+        try:
+            await asyncio.wait_for(self.set_cleaner_state(request), timeout=30)
+            _LOGGER.debug("Cleared desired state to prevent auto-restart")
+        except Exception as e:
+            _LOGGER.warning(f"Failed to clear desired state: {e}")
+
     async def stop_cleaning(self):
         """Stop the vacuum cleaning."""
         request = None
@@ -2726,6 +2767,17 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator):
                 merged_data.get("activity") == "cleaning" and
                     self._last_data.get("cycle_start_time")):
                 merged_data["cycle_start_time"] = self._last_data["cycle_start_time"]
+
+            # Detect natural cleaning → idle transition and clear desired state
+            # This prevents the cloud from auto-restarting the robot
+            if (self._last_data.get("activity") == "cleaning" and
+                merged_data.get("activity") == "idle" and
+                    not self.client._pending_stop_reset):  # Not a manual stop
+                _LOGGER.info("Robot finished cleaning naturally - clearing desired state to prevent auto-restart")
+                try:
+                    await self.client.clear_desired_state()
+                except Exception as e:
+                    _LOGGER.warning(f"Failed to clear desired state after natural completion: {e}")
 
             # Reset failure count on successful update
             self._consecutive_failures = 0


### PR DESCRIPTION
Fixes #89.

## Summary

When a Polaris VRX IQ+ robotic cleaner finishes a cleaning cycle naturally (without a manual stop), the iAqualink cloud retains `desired.state = 1` (cleaning). The cloud detects the mismatch between desired (cleaning) and reported (idle) state and sends a command to restart the robot, causing it to run another full ~2 hour cycle immediately.

This patch adds an `AqualinkClient.clear_desired_state()` method that POSTs `desired.equipment.robot.state = 0` via the existing `setCleanerState` action — the same payload `stop_cleaning()` already uses for vr robots, so the cloud-side contract is unchanged.

The coordinator's `_async_update_data` detects a `cleaning → idle` transition between `_last_data` and the freshly fetched status and calls `clear_desired_state()`. Currently scoped to `_device_type == "vr"`; other device types (vortrax, cyclobat, cyclonext) early-return until someone reports the same bug there.

Tested on a Polaris VRX IQ+ (vr device type) running against a live iAqualink account; the auto-restart no longer occurs after a natural cycle end. Has been running in my Home Assistant install since early January without incident.

## Known limitations / open questions

I'd rather flag these honestly than hide them. None are blockers for the reported case, but the maintainer (or a follow-up PR) may want to address some of them:

1. **The `not _pending_stop_reset` guard is racier than the comment implies.** `_pending_stop_reset` is consumed inside `fetch_status` (coordinator.py:314-317) during the same call that produces `merged_data`. By the time the coordinator inspects it at the new check, a manual stop has already cleared it, so `clear_desired_state()` fires on manual stops too. The payload is byte-identical to what `stop_cleaning()` just sent for vr, so it's idempotent and harmless in practice — but the comment `# Not a manual stop` is misleading and I'm happy to either reword it or rework the guard (e.g. a short-lived "recently stopped" timestamp on the client) if you prefer.

2. **Robots that pass through `returning` before `idle` are not covered.** For vr, `robot_state == 3` maps to `activity = "returning"`. If a model exits a cycle as `cleaning → returning → idle`, the previous activity seen by the coordinator will be `"returning"`, not `"cleaning"`, and the detection won't fire. My VRX IQ+ transitions straight to idle (no docking step), which is why it works for me. Broadening the check to `_last_data.get("activity") in ("cleaning", "returning")` would cover more hardware — happy to do that if you can confirm it's the right behaviour for returning robots.

3. **No debounce — single-poll glitches are now actionable.** Previously a transient bad poll showing `idle` mid-cycle just blipped the UI for one poll. Now it would send `state = 0` and could actively stop the robot. I haven't seen this happen in practice, but the detection has no "stable for N polls" check or cross-check against the websocket stream.

4. **Misleading log line for non-vr devices.** The coordinator logs `"Robot finished cleaning naturally - clearing desired state to prevent auto-restart"` before checking device type; `clear_desired_state()` silently no-ops for non-vr. Cosmetic — easy to guard the log on `self.client._device_type == "vr"` if you'd like.

5. **No regression test.** The recently added `tests/` scaffold covers `config_flow` but not coordinator data flow. A test that feeds `_last_data = {"activity": "cleaning"}` and a status returning `activity = "idle"` and asserts `clear_desired_state` is invoked would protect this against future refactors of `coordinator.py`. Happy to add one in this PR or a follow-up if you want.

Let me know which of these (if any) you'd like addressed before merge — I can push fixes onto this branch.
